### PR TITLE
fix: simplify kernel build workflow and remove read-only filesystem issues

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -76,12 +76,11 @@ jobs:
 
       - name: Create workspace directories
         run: |
-          mkdir -p kernel-source
-          mkdir -p kernel-build
+          mkdir -p kernel-workspace
 
       - name: Clone Linux kernel
         run: |
-          cd kernel-source
+          cd kernel-workspace
           git clone --depth 1 --branch ${{ steps.params.outputs.kernel_version }} ${{ env.KERNEL_REPO }} linux
           cd linux
           echo "Cloned Linux kernel ${{ steps.params.outputs.kernel_version }}"
@@ -90,7 +89,7 @@ jobs:
       - name: Get kernel information
         id: kernel-info
         run: |
-          cd kernel-source/linux
+          cd kernel-workspace/linux
           KERNEL_VERSION=$(make kernelversion)
           KERNEL_COMMIT=$(git rev-parse --short HEAD)
           echo "version=${KERNEL_VERSION}" >> $GITHUB_OUTPUT
@@ -101,29 +100,25 @@ jobs:
       - name: Build kernel with compile_commands.json
         run: |
           docker run --rm \
-            -v $(pwd)/kernel-source:/mnt/input:ro \
-            -v $(pwd)/kernel-build:/mnt/output \
+            -v $(pwd)/kernel-workspace:/mnt/workspace \
             ${{ env.REGISTRY }}/${{ github.repository }}/kernel-build:latest \
             /mnt/scripts/kernel-build.sh \
-              -s /mnt/input/linux \
-              -o /mnt/output \
+              -s /mnt/workspace/linux \
               -c ${{ steps.params.outputs.kernel_config }} \
               -a ${{ steps.params.outputs.arch }}
 
       - name: Verify build artifacts
         run: |
           echo "Build artifacts:"
-          ls -la kernel-build/
+          ls -la kernel-workspace/linux/
           echo "Compile commands file size:"
-          du -h kernel-build/compile_commands.json
+          du -h kernel-workspace/linux/compile_commands.json
 
       - name: Upload kernel artifacts
         uses: actions/upload-artifact@v4
         with:
           name: kernel-artifacts
-          path: |
-            kernel-source/
-            kernel-build/
+          path: kernel-workspace/
           retention-days: 1
 
   generate-codebrowser:
@@ -146,13 +141,12 @@ jobs:
       - name: Generate codebrowser HTML
         run: |
           docker run --rm \
-            -v $(pwd)/kernel-source:/mnt/input:ro \
-            -v $(pwd)/kernel-build:/mnt/build:ro \
+            -v $(pwd)/kernel-workspace:/mnt/input:ro \
             -v $(pwd)/codebrowser-output:/mnt/output \
             ${{ env.REGISTRY }}/${{ github.repository }}/codebrowser:latest \
             /mnt/scripts/generate-codebrowser.sh \
               -i /mnt/input/linux \
-              -b /mnt/build \
+              -b /mnt/input/linux \
               -o /mnt/output \
               -p "Linux Kernel ${{ needs.build-kernel.outputs.kernel-version }} (${{ needs.build-kernel.outputs.kernel-commit }})"
 


### PR DESCRIPTION
Simplify Docker volume mounting and kernel-build script to resolve build failures:

- Remove read-only mount flags from kernel source directory in build-kernel job
- Consolidate kernel-source and kernel-build directories into single kernel-workspace
- Simplify kernel-build.sh script by removing OUTPUT_DIR parameter support
- Fix .config file path checks in kernel-build.sh (use relative paths in source directory)
- Remove unnecessary file copying logic since build happens directly in source directory
- Update all volume mount paths in workflow to use unified workspace approach

Build process improvements:
- Kernel compilation now happens directly in source directory (standard practice)
- compile_commands.json generated in same location as source code
- Eliminates "Read-only file system" errors during kernel configuration
- Reduces complexity by removing separate input/output directory management
- Maintains security by using read-only mounts only where appropriate (codebrowser step)

Script changes:
- Remove -o/--output-dir parameter from kernel-build.sh
- Simplify help text and parameter parsing
- Update error messages to reflect new single-directory approach
- Fix all file path references to work within source directory

This resolves the mkdir permission errors during kernel build while maintaining
a clean and straightforward build process.

Note: Changes and commit message generated by GitHub Copilot
