### PR TITLE
fix: improve GitHub Pages workflow with compression and simplified kernel build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -114,11 +114,17 @@ jobs:
           echo "Compile commands file size:"
           du -h kernel-workspace/linux/compile_commands.json
 
+      - name: Compress kernel artifacts
+        run: |
+          tar -czf kernel-workspace.tar.gz kernel-workspace/
+          echo "Compressed kernel workspace:"
+          ls -lh kernel-workspace.tar.gz
+
       - name: Upload kernel artifacts
         uses: actions/upload-artifact@v4
         with:
           name: kernel-artifacts
-          path: kernel-workspace/
+          path: kernel-workspace.tar.gz
           retention-days: 1
 
   generate-codebrowser:
@@ -133,6 +139,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: kernel-artifacts
+
+      - name: Extract kernel artifacts
+        run: |
+          tar -xzf kernel-workspace.tar.gz
+          rm kernel-workspace.tar.gz
+          echo "Extracted kernel workspace:"
+          ls -la kernel-workspace/linux/
 
       - name: Create output directory
         run: |


### PR DESCRIPTION
Enhance workflow reliability and efficiency:

- Add compression for kernel artifacts to resolve case-sensitivity issues with GitHub Actions artifacts
- Compress kernel workspace with tar/gzip before upload to reduce transfer time and storage usage
- Add extraction step in codebrowser generation job to decompress artifacts
- Improve artifact handling with proper cleanup of compressed files

The compression addresses GitHub Actions artifact upload/download issues related to
case-sensitive filenames and improves overall workflow performance by reducing
the size of transferred artifacts.

Note: Changes and commit message generated by GitHub Copilot
