### PR TITLE
fix: add kernel build dependencies to codebrowser image

### DIFF
--- a/docker/codebrowser.Dockerfile
+++ b/docker/codebrowser.Dockerfile
@@ -11,12 +11,25 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
     build-essential \
+    make \
     cmake \
     git \
     llvm-dev \
     libclang-dev \
     clang \
+    lld \
     libclang-cpp-dev \
+    bc \
+    bison \
+    flex \
+    libssl-dev \
+    libelf-dev \
+    libncurses5-dev \
+    libncursesw5-dev \
+    xz-utils \
+    kmod \
+    cpio \
+    python3-dev \
     curl \
     ca-certificates \
     && apt-get autoremove -y \


### PR DESCRIPTION
- Add all necessary build tools and libraries required for kernel compilation
- Include bc, bison, flex, libssl-dev, libelf-dev, and other essential packages
- Ensure codebrowser can properly resolve all system headers and symbols
- Fix missing dependencies that could cause incomplete code indexing

This ensures the codebrowser generator has access to the same build
environment as the kernel compilation, enabling accurate parsing and
cross-referencing of kernel source code.
