### PR TITLE
fix: improve codebrowser generation with better output structure and CSS support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -194,12 +194,29 @@ jobs:
               -i /mnt/source/linux \
               -b /mnt/build \
               -o /mnt/output \
-              -p "Linux Kernel ${{ needs.build-kernel.outputs.kernel-version }} (${{ needs.build-kernel.outputs.kernel-commit }})"
+              -p "Linux Kernel" \
+              -v "${{ needs.build-kernel.outputs.kernel-version }} (${{ needs.build-kernel.outputs.kernel-commit }})"
 
       - name: Verify codebrowser output
         run: |
-          echo "Codebrowser output:"
+          echo "Codebrowser output structure:"
+          find codebrowser-output/ -type f | head -20
+          echo "Root directory contents:"
           ls -la codebrowser-output/
+          echo "Checking for index.html in root:"
+          if [[ -f codebrowser-output/index.html ]]; then
+            echo "✓ index.html found in root"
+          else
+            echo "✗ index.html not found in root - checking subdirectories:"
+            find codebrowser-output/ -name "index.html"
+          fi
+          echo "Checking for data directory and CSS files:"
+          if [[ -d codebrowser-output/data ]]; then
+            echo "Data directory exists:"
+            ls -la codebrowser-output/data/
+          else
+            echo "Warning: Data directory not found!"
+          fi
           echo "Total size:"
           du -sh codebrowser-output/
 

--- a/docker/codebrowser.Dockerfile
+++ b/docker/codebrowser.Dockerfile
@@ -42,6 +42,7 @@ RUN git clone https://github.com/KDAB/codebrowser.git && \
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local . && \
     make -j$(nproc) && \
     make install && \
+    cp -r data /usr/local/share/codebrowser-data && \
     cd .. && \
     rm -rf codebrowser
 

--- a/docker/scripts/generate-codebrowser.sh
+++ b/docker/scripts/generate-codebrowser.sh
@@ -9,12 +9,12 @@
 
 set -euo pipefail
 
-# Default values
-INPUT_DIR="/mnt/input"
-OUTPUT_DIR="/mnt/output"
-PROJECT_NAME="kernel"
+# Variables (no default values)
+INPUT_DIR=""
+OUTPUT_DIR=""
+PROJECT_NAME=""
 BUILD_DIR=""
-DATA_URL="../data"
+PROJECT_VERSION=""
 
 # Function to show help
 show_help() {
@@ -24,40 +24,60 @@ Usage: $(basename "$0") [OPTIONS]
 Generate codebrowser HTML from kernel source code.
 
 OPTIONS:
-    -i DIR      Input directory containing kernel source (default: /mnt/input)
-    -o DIR      Output directory for generated HTML (default: /mnt/output)
-    -b DIR      Build directory containing compile_commands.json
-    -p NAME     Project name (default: kernel)
-    -d URL      Data URL for CSS/JS files (default: ../data)
+    -i DIR      Input directory containing kernel source (required)
+    -o DIR      Output directory for generated HTML (required)
+    -b DIR      Build directory containing compile_commands.json (required)
+    -p NAME     Project name (required)
+    -v VERSION  Project version (required)
     -h          Show this help message
 
 EXAMPLE:
-    $(basename "$0") -i /mnt/input/linux -o /mnt/output -b /mnt/input/linux/build -p "Linux Kernel"
+    $(basename "$0") -i /mnt/input/linux -o /mnt/output -b /mnt/input/linux/build -p "Linux Kernel" -v "6.8"
 
 EOF
 }
 
 # Parse command line arguments
-while getopts "i:o:b:p:d:h" opt; do
+while getopts "i:o:b:p:v:h" opt; do
     case $opt in
         i) INPUT_DIR="$OPTARG" ;;
         o) OUTPUT_DIR="$OPTARG" ;;
         b) BUILD_DIR="$OPTARG" ;;
         p) PROJECT_NAME="$OPTARG" ;;
-        d) DATA_URL="$OPTARG" ;;
+        v) PROJECT_VERSION="$OPTARG" ;;
         h) show_help; exit 0 ;;
         *) echo "Invalid option. Use -h for help."; exit 1 ;;
     esac
 done
 
 # Validate inputs
-if [[ ! -d "$INPUT_DIR" ]]; then
-    echo "Error: Input directory '$INPUT_DIR' does not exist."
+if [[ -z "$INPUT_DIR" ]]; then
+    echo "Error: Input directory must be specified with -i option."
+    exit 1
+fi
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+    echo "Error: Output directory must be specified with -o option."
     exit 1
 fi
 
 if [[ -z "$BUILD_DIR" ]]; then
     echo "Error: Build directory must be specified with -b option."
+    exit 1
+fi
+
+if [[ -z "$PROJECT_NAME" ]]; then
+    echo "Error: Project name must be specified with -p option."
+    exit 1
+fi
+
+if [[ -z "$PROJECT_VERSION" ]]; then
+    echo "Error: Project version must be specified with -v option."
+    exit 1
+fi
+
+if [[ ! -d "$INPUT_DIR" ]]; then
+    echo "Error: Input directory '$INPUT_DIR' does not exist."
     exit 1
 fi
 
@@ -67,30 +87,41 @@ if [[ ! -f "$BUILD_DIR/compile_commands.json" ]]; then
     exit 1
 fi
 
-# Create output directory
-mkdir -p "$OUTPUT_DIR"
+# Create output directory with project name and version subdirectory
+FINAL_OUTPUT_DIR="$OUTPUT_DIR/$PROJECT_NAME:$PROJECT_VERSION"
+mkdir -p "$FINAL_OUTPUT_DIR"
 
 echo "Starting codebrowser generation..."
 echo "Input: $INPUT_DIR"
 echo "Output: $OUTPUT_DIR"
+echo "Final Output: $FINAL_OUTPUT_DIR"
 echo "Build: $BUILD_DIR"
 echo "Project: $PROJECT_NAME"
+echo "Version: $PROJECT_VERSION"
 
 # Run codebrowser generator
 codebrowser_generator \
     -a \
-    -o "$OUTPUT_DIR" \
+    -o "$FINAL_OUTPUT_DIR" \
     -b "$BUILD_DIR" \
-    -p "$PROJECT_NAME:$INPUT_DIR" \
-    -d "$DATA_URL"
+    -p "$PROJECT_NAME:$PROJECT_VERSION:$INPUT_DIR"
 
 # Generate index
 if command -v codebrowser_indexgenerator &> /dev/null; then
     echo "Generating index..."
-    codebrowser_indexgenerator "$OUTPUT_DIR"
+    codebrowser_indexgenerator "$INPUT_DIR"
 else
     echo "Warning: codebrowser_indexgenerator not found. Index will not be generated."
 fi
 
+# Copy data directory to output directory
+if [[ -d "/usr/local/share/codebrowser-data" ]]; then
+    echo "Copying data directory to output..."
+    cp -r /usr/local/share/codebrowser-data "$OUTPUT_DIR/data"
+    echo "Data directory copied to $OUTPUT_DIR/data"
+else
+    echo "Warning: Data directory not found at /usr/local/share/codebrowser-data"
+fi
+
 echo "Codebrowser generation complete!"
-echo "Output directory: $OUTPUT_DIR"
+echo "Output directory: $FINAL_OUTPUT_DIR"


### PR DESCRIPTION
- Remove -d parameter from generate-codebrowser.sh as it's not needed
- Add -v parameter for project version to separate project name and version
- Create project-specific subdirectory structure: "ProjectName:Version"
- Preserve codebrowser data directory in Docker image for CSS/JS resources
- Copy data directory to output root to ensure proper CSS/JS file access
- Update workflow to pass separate project name and version parameters
- Enhance output verification with better directory structure checks

This ensures the generated codebrowser has proper CSS styling and maintains
a clean directory structure that supports multiple project versions.
